### PR TITLE
Fix compilation with clang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        compiler:
+          - { name: gcc, version: 11}
+          - { name: gcc, version: 12}
+          - { name: gcc, version: 13}
+          - { name: gcc, version: 14}
+          - { name: clang, version: 16}
+          - { name: clang, version: 17}
+          - { name: clang, version: 18}
+    name: Build (${{ matrix.compiler.name }} ${{ matrix.compiler.version }})
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo add-apt-repository universe
+          sudo apt-get update
+          sudo apt-get install --assume-yes --no-install-recommends ca-certificates cmake git
+      - name: Install GCC
+        if: ${{ matrix.compiler.name == 'gcc' }}
+        run: |
+          sudo apt-get install --assume-yes --no-install-recommends gcc-${{ matrix.compiler.version }} g++-${{ matrix.compiler.version }}
+          echo "CC=/usr/bin/gcc-${{ matrix.compiler.version }}" >> $GITHUB_ENV
+          echo "CXX=/usr/bin/g++-${{ matrix.compiler.version }}" >> $GITHUB_ENV
+      - name: Install Clang
+        if: ${{ matrix.compiler.name == 'clang' }}
+        run: |
+          sudo apt-get install --assume-yes --no-install-recommends clang-${{ matrix.compiler.version }}
+          echo "CC=/usr/bin/clang-${{ matrix.compiler.version }}" >> $GITHUB_ENV
+          echo "CXX=/usr/bin/clang++-${{ matrix.compiler.version }}" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build
+        run: |
+          cmake -B ./build
+          cmake --build ./build --parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,7 @@ if (NOT TARGET BITS)
   add_library(BITS INTERFACE)
   target_include_directories(BITS INTERFACE .)
   target_include_directories(BITS INTERFACE ./include)
-
   target_compile_features(BITS INTERFACE cxx_std_17)
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    target_compile_options(BITS INTERFACE -stdlib=libc++)
-  endif()
 
   MESSAGE(STATUS "Compiling for processor: " ${CMAKE_HOST_SYSTEM_PROCESSOR})
 
@@ -25,8 +21,6 @@ if (NOT TARGET BITS)
   endif()
 
   if (UNIX)
-    MESSAGE(STATUS "Compiling with flags: -std=c++17 -ggdb -Wall -Wextra -Wno-missing-braces -Wno-unknown-attributes -Wno-unused-function")
-
     target_compile_options(BITS INTERFACE -ggdb)
     target_compile_options(BITS INTERFACE -Wall -Wextra -Wno-missing-braces -Wno-unknown-attributes -Wno-unused-function)
 


### PR DESCRIPTION
The first commit adds a CI test to compile with clang (which fails). The second commit repairs clang compilation by removing manual management of compile parameters that cmake already properly handles for us.

See https://github.com/ByteHamster-etc/bits/commits/fix-clang/ for the test runs (this repo doesn't have CI enabled).