### PR TITLE
Upgrade to cmake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(BITS)
 
 if (NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Cmake 4.0 refuses to compile projects that specify 3.5. Not even a warning, it just doesn't compile