### PR TITLE
Use pod_vector for mmap zero-copy support in serialized data structures

### DIFF
--- a/include/bit_vector.hpp
+++ b/include/bit_vector.hpp
@@ -41,7 +41,7 @@ struct bit_vector  //
 
         void build(bit_vector& bv) {
             bv.m_num_bits = m_num_bits;
-            bv.m_data.swap(m_data);
+            bv.m_data = std::move(m_data);
             builder().swap(*this);
         }
 
@@ -322,7 +322,7 @@ struct bit_vector  //
     iterator begin() const { return get_iterator_at(0); }
 
     uint64_t num_bits() const { return m_num_bits; }
-    std::vector<uint64_t> const& data() const { return m_data; }
+    essentials::owning_span<uint64_t> const& data() const { return m_data; }
 
     uint64_t num_bytes() const { return sizeof(m_num_bits) + essentials::vec_bytes(m_data); }
 
@@ -343,7 +343,7 @@ struct bit_vector  //
 
 protected:
     uint64_t m_num_bits;
-    std::vector<uint64_t> m_data;
+    essentials::owning_span<uint64_t> m_data;
 
     template <typename Visitor, typename T>
     static void visit_impl(Visitor& visitor, T&& t) {

--- a/include/cache_line_elias_fano.hpp
+++ b/include/cache_line_elias_fano.hpp
@@ -52,10 +52,9 @@ struct cache_line_elias_fano {
 
         const uint64_t num_blocks = (n + 44 - 1) / 44;
         const uint64_t num_bytes = num_blocks * 64;
-        m_bits.resize(num_bytes);
-        std::fill(m_bits.begin(), m_bits.end(), 0);
+        std::vector<uint8_t> bits(num_bytes);
 
-        uint8_t* high = m_bits.data();
+        uint8_t* high = bits.data();
         uint8_t* low = high + 4  // for lower bound high part of block
                        + 16;     // for high bits
 
@@ -100,6 +99,7 @@ struct cache_line_elias_fano {
         }
 
         m_back = last;
+        m_bits = essentials::owning_span<uint8_t>(std::move(bits));
     }
 
     uint64_t access(uint64_t i) const {
@@ -149,7 +149,7 @@ struct cache_line_elias_fano {
 private:
     uint64_t m_back;
     uint64_t m_size;
-    std::vector<uint8_t> m_bits;
+    essentials::owning_span<uint8_t> m_bits;
 
     template <typename Visitor, typename T>
     static void visit_impl(Visitor& visitor, T&& t) {

--- a/include/compact_vector.hpp
+++ b/include/compact_vector.hpp
@@ -195,7 +195,7 @@ struct compact_vector  //
             cv.m_size = m_size;
             cv.m_width = m_width;
             cv.m_mask = m_mask;
-            cv.m_data.swap(m_data);
+            cv.m_data = std::move(m_data);
             builder().swap(*this);
         }
 
@@ -262,7 +262,7 @@ struct compact_vector  //
     uint64_t back() const { return operator[](size() - 1); }
     uint64_t size() const { return m_size; }
     uint64_t width() const { return m_width; }
-    std::vector<uint64_t> const& data() const { return m_data; }
+    essentials::owning_span<uint64_t> const& data() const { return m_data; }
 
     typedef enumerator<compact_vector> iterator;
     iterator get_iterator_at(uint64_t pos) const { return iterator(this, pos); }
@@ -293,7 +293,7 @@ private:
     uint64_t m_size;
     uint64_t m_width;
     uint64_t m_mask;
-    std::vector<uint64_t> m_data;
+    essentials::owning_span<uint64_t> m_data;
 
     template <typename Visitor, typename T>
     static void visit_impl(Visitor& visitor, T&& t) {

--- a/include/darray.hpp
+++ b/include/darray.hpp
@@ -81,7 +81,7 @@ struct darray {
     darray() : m_positions(0) {}
 
     void build(bit_vector const& B) {
-        std::vector<uint64_t> const& data = B.data();
+        auto const& data = B.data();
         std::vector<uint64_t> cur_block_positions;
         std::vector<int64_t> block_inventory;
         std::vector<uint16_t> subblock_inventory;
@@ -113,9 +113,9 @@ struct darray {
             flush_cur_block(cur_block_positions, block_inventory, subblock_inventory,
                             overflow_positions);
         }
-        m_block_inventory.swap(block_inventory);
-        m_subblock_inventory.swap(subblock_inventory);
-        m_overflow_positions.swap(overflow_positions);
+        m_block_inventory = std::move(block_inventory);
+        m_subblock_inventory = std::move(subblock_inventory);
+        m_overflow_positions = std::move(overflow_positions);
 
         // std::cout << "I: ";
         // for (auto x : m_block_inventory) { std::cout << x << ' '; }
@@ -174,7 +174,7 @@ struct darray {
         uint64_t reminder = i & (subblock_size - 1);
         if (!reminder) return start_pos;
 
-        std::vector<uint64_t> const& data = B.data();
+        auto const& data = B.data();
         uint64_t word_idx = start_pos >> 6;
         uint64_t word_shift = start_pos & 63;
         uint64_t word = WordGetter()(data, word_idx) & (uint64_t(-1) << word_shift);
@@ -214,9 +214,9 @@ struct darray {
 
 protected:
     uint64_t m_positions;
-    std::vector<int64_t> m_block_inventory;
-    std::vector<uint16_t> m_subblock_inventory;
-    std::vector<uint64_t> m_overflow_positions;
+    essentials::owning_span<int64_t> m_block_inventory;
+    essentials::owning_span<uint16_t> m_subblock_inventory;
+    essentials::owning_span<uint64_t> m_overflow_positions;
 
     template <typename Visitor, typename T>
     static void visit_impl(Visitor& visitor, T&& t) {
@@ -262,11 +262,13 @@ protected:
 namespace util {
 
 struct identity_getter {
-    uint64_t operator()(std::vector<uint64_t> const& data, uint64_t i) const { return data[i]; }
+    template <typename Vec>
+    uint64_t operator()(Vec const& data, uint64_t i) const { return data[i]; }
 };
 
 struct negating_getter {
-    uint64_t operator()(std::vector<uint64_t> const& data, uint64_t i) const { return ~data[i]; }
+    template <typename Vec>
+    uint64_t operator()(Vec const& data, uint64_t i) const { return ~data[i]; }
 };
 
 }  // namespace util

--- a/include/endpoints_sequence.hpp
+++ b/include/endpoints_sequence.hpp
@@ -50,7 +50,8 @@ struct endpoints_sequence {
 
         const uint64_t num_high_bits = n + (universe >> 8) + 1;
         bit_vector::builder bvb_high_bits(num_high_bits);
-        m_low_bits.reserve(n);
+        std::vector<uint8_t> low_bits;
+        low_bits.reserve(n);
 
         compact_vector::builder cvb_hints_0((universe + 256 - 1) / 256,  // ceil(U/2^8)
                                             util::ceil_log2_uint64(num_high_bits));
@@ -59,7 +60,7 @@ struct endpoints_sequence {
         uint64_t prev_pos = 0;
         for (uint64_t i = 0; i != n; ++i, ++begin) {
             auto v = *begin;
-            m_low_bits.push_back(v & 255);
+            low_bits.push_back(v & 255);
             uint64_t high_part = v >> 8;
             uint64_t pos = high_part + i;
             bvb_high_bits.set(pos, 1);
@@ -72,6 +73,7 @@ struct endpoints_sequence {
         bvb_high_bits.build(m_high_bits);
         m_high_bits_d1.build(m_high_bits);
         cvb_hints_0.build(m_hints_0);
+        m_low_bits = essentials::owning_span<uint8_t>(std::move(low_bits));
     }
 
     struct iterator {
@@ -141,7 +143,7 @@ struct endpoints_sequence {
         uint64_t m_pos;
         uint64_t m_val;
         bit_vector::iterator m_high_bits_it;
-        std::vector<uint8_t>::const_iterator m_low_bits_it;
+        const uint8_t* m_low_bits_it;
 
         void read_next_value() {
             assert(m_pos < m_ptr->size());
@@ -226,7 +228,7 @@ private:
     bit_vector m_high_bits;
     DArray1 m_high_bits_d1;
     compact_vector m_hints_0;
-    std::vector<uint8_t> m_low_bits;
+    essentials::owning_span<uint8_t> m_low_bits;
 
     template <typename Visitor, typename T>
     static void visit_impl(Visitor& visitor, T&& t) {

--- a/include/rank9.hpp
+++ b/include/rank9.hpp
@@ -46,7 +46,7 @@ struct rank9 {
     rank9() {}
 
     void build(bit_vector const& B) {
-        std::vector<uint64_t> const& data = B.data();
+        auto const& data = B.data();
         std::vector<uint64_t> block_rank_pairs;
         uint64_t next_rank = 0;
         uint64_t cur_subrank = 0;
@@ -81,7 +81,7 @@ struct rank9 {
             block_rank_pairs.push_back(0);
         }
 
-        m_block_rank_pairs.swap(block_rank_pairs);
+        m_block_rank_pairs = std::move(block_rank_pairs);
     }
 
     inline uint64_t num_ones() const { return *(m_block_rank_pairs.end() - 2); }
@@ -96,7 +96,7 @@ struct rank9 {
         uint64_t r = sub_block_rank(sub_block);
         uint64_t sub_left = i % 64;
         if (sub_left) {
-            std::vector<uint64_t> const& data = B.data();
+            auto const& data = B.data();
             r += util::popcount(data[sub_block] << (64 - sub_left));
         }
         return r;
@@ -146,7 +146,7 @@ private:
     }
 
     static const uint64_t block_size = 8;  // in 64bit words
-    std::vector<uint64_t> m_block_rank_pairs;
+    essentials::owning_span<uint64_t> m_block_rank_pairs;
 };
 
 }  // namespace bits


### PR DESCRIPTION
## Summary

This PR replaces `std::vector` with `essentials::pod_vector` in all serialized data structure members across `bits`. This is a companion to [jermp/essentials#11](https://github.com/jermp/essentials/pull/11), which introduces `pod_vector` and mmap zero-copy loading support in `generic_loader`.

No behavioral change for existing code — `pod_vector` is a drop-in replacement for `std::vector` when used in owned mode (the default). The change enables downstream applications to use `generic_loader::set_mmap()` to deserialize these data structures via zero-copy views into memory-mapped files. See the essentials PR for full motivation, benchmarks, and design details.

## Changes

| File | Member | Before | After |
|------|--------|--------|-------|
| `bit_vector.hpp` | `m_bits` | `std::vector<uint64_t>` | `pod_vector<uint64_t>` |
| `compact_vector.hpp` | `m_bits` | `std::vector<uint64_t>` | `pod_vector<uint64_t>` |
| `rank9.hpp` | `m_block_rank_pairs` | `std::vector<uint64_t>` | `pod_vector<uint64_t>` |
| `darray.hpp` | `m_positions` | `std::vector<uint64_t>` | `pod_vector<uint64_t>` |
| `cache_line_elias_fano.hpp` | `m_data` | `std::vector<uint8_t>` | `pod_vector<uint8_t>` |
| `endpoints_sequence.hpp` | `m_hints_0` | `std::vector<uint8_t>` | `pod_vector<uint8_t>` |

Additionally, `darray.hpp` templatizes `access()` and `at()` to accept both `const uint64_t*` and `pod_vector<uint64_t>::const_iterator` for const correctness.

**Depends on:** [jermp/essentials#11](https://github.com/jermp/essentials/pull/11)
